### PR TITLE
Fix script generator and example

### DIFF
--- a/example.py
+++ b/example.py
@@ -42,7 +42,7 @@ def model_forward_pass(input_tensor, model_weights, config):
     hidden = torch.relu(hidden)
     
     if config.get('use_dropout', False):
-        hidden = torch.dropout(hidden, p=config.get('dropout_rate', 0.5))
+        hidden = torch.nn.functional.dropout(hidden, p=config.get('dropout_rate', 0.5))
     
     output = torch.matmul(hidden, model_weights['linear2'])
     

--- a/script_generator.py
+++ b/script_generator.py
@@ -360,3 +360,4 @@ def _generate_batch_main_block(calls: List[FunctionCall], group_by_function: boo
 if __name__ == "__main__":
     success = run_all_tests()
     sys.exit(0 if success else 1)
+'''


### PR DESCRIPTION
## Summary
- fix unterminated string in script generation
- correct dropout call in example

## Testing
- `python -m py_compile capture.py serialization.py script_generator.py utils.py __init__.py example.py`
- `python -m debug_utils.example`

------
https://chatgpt.com/codex/tasks/task_e_686d4630a0708327909a5c5d5731ec02